### PR TITLE
minimal version bump for mock-server java-client from 3.10 to 3.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val `mockserver-client-scala` = (project in file("."))
   .settings(name := "mockserver-client-scala")
-  .settings(version := "0.2.0")
-  .settings(scalaVersion := "2.11.7")
+  .settings(version := "0.2.1")
+  .settings(scalaVersion := "2.11.8")
   .settings(organization := "com.github.unisay")
   .settings(licenses += ("MIT", url("http://opensource.org/licenses/MIT")))
   .settings(publishMavenStyle := true)
@@ -9,10 +9,29 @@ lazy val `mockserver-client-scala` = (project in file("."))
   .settings(bintrayRepository := "maven")
   .settings(bintrayOrganization := None)
   .settings(libraryDependencies ++= Seq(
-    "org.mock-server"            %  "mockserver-client-java"      % "3.10.0",
+    "org.mock-server"            %  "mockserver-client-java"      % "3.11",
     "org.slf4j"                  %  "slf4j-api"                   % "1.7.12",
     "ch.qos.logback"             %  "logback-classic"             % "1.1.3",
     "com.typesafe.scala-logging" %% "scala-logging"               % "3.0.0",
     "org.scalatest"              %% "scalatest"                   % "2.2.5"    % "test",
     "org.scalamock"              %% "scalamock-scalatest-support" % "3.2.2"    % "test"
+  ))
+  .settings(scalacOptions ++= Seq(
+    "-encoding", "UTF-8",
+    "-deprecation", // warning and location for usages of deprecated APIs
+    "-feature", // warning and location for usages of features that should be imported explicitly
+    "-unchecked", // additional warnings where generated code depends on assumptions
+    "-Xlint:_", // recommended additional warnings
+    "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver
+    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused
+    "-Ywarn-unused-import", // Warn when imports are unused
+    "-Ywarn-unused", // Warn when local and private vals, vars, defs, and types are unused
+    "-Ywarn-numeric-widen", // Warn when numerics are widened, Int and Double, for instance
+    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+    "-Ywarn-dead-code", // Warn when dead code is identified
+    "-Ywarn-infer-any", // Warn when a type argument is inferred to be `Any`
+    "-Ywarn-nullary-override", //  Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Ywarn-nullary-unit", // Warn when nullary methods return Unit
+    "-language:reflectiveCalls",
+    "-language:postfixOps" // too lazy?
   ))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.15


### PR DESCRIPTION
Dear Yuriy Lazarev,

minimal suggested version bumps for mock-server java-client from 3.10.0 to 3.11, scala, and sbt and a nice selection of scalacOptions.

Best regards,
Alex